### PR TITLE
set default steps if steps of the calculation are empty

### DIFF
--- a/pkg/dispatcher/workerpools/controller_test.go
+++ b/pkg/dispatcher/workerpools/controller_test.go
@@ -185,6 +185,20 @@ func TestReconcile(t *testing.T) {
 									Teff: 10000.0,
 									LogG: 4.0,
 								},
+								Steps: []v1.Step{
+									{
+										Command: "atlas12_ada",
+										Args:    []string{"s"},
+									},
+									{
+										Command: "atlas12_ada",
+										Args:    []string{"r"},
+									},
+									{
+										Command: "synspec49",
+										Args:    []string{"<", "input_tlusty_fortfive"},
+									},
+								},
 							},
 						),
 						Namespace: "vega",
@@ -199,6 +213,20 @@ func TestReconcile(t *testing.T) {
 					Spec: v1.CalculationSpec{
 						Teff: 10000,
 						LogG: 4,
+						Steps: []v1.Step{
+							{
+								Command: "atlas12_ada",
+								Args:    []string{"s"},
+							},
+							{
+								Command: "atlas12_ada",
+								Args:    []string{"r"},
+							},
+							{
+								Command: "synspec49",
+								Args:    []string{"<", "input_tlusty_fortfive"},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/util/calculations.go
+++ b/pkg/util/calculations.go
@@ -13,6 +13,23 @@ import (
 // NewCalculation gets the values of teff and logG and creates a calculation
 // with its minumum values
 func NewCalculation(calc *bulkv1.Calculation) *v1.Calculation {
+	if len(calc.Steps) == 0 {
+		calc.Steps = []v1.Step{
+			{
+				Command: "atlas12_ada",
+				Args:    []string{"s"},
+			},
+			{
+				Command: "atlas12_ada",
+				Args:    []string{"r"},
+			},
+			{
+				Command: "synspec49",
+				Args:    []string{"<", "input_tlusty_fortfive"},
+			},
+		}
+	}
+
 	calcSpec := v1.CalculationSpec{
 		Teff:  calc.Params.Teff,
 		LogG:  calc.Params.LogG,


### PR DESCRIPTION
Hey @droslean,
whenever a calculation without steps wants to get created, we put in default steps for the calculation.
Test case for this change was already somewhat in one of the test, so i just modified it.

Signed-off-by: Daniel Odvarka <odvarkaadaniel@gmail.com>