### PR TITLE
add/delete funcionality to the api

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	r.GET("/workerpools", s.getWorkerPools)
 	r.GET("/workerpool/:id", s.getWorkerPoolByName)
-	r.POST("workerpool/create/:id", s.createWorkerPool)
+	r.POST("workerpool/create", s.createWorkerPool)
 	r.DELETE("/workerpools/delete/:id", s.deleteWorkerPool)
 
 	r.GET("/healthz", func(c *gin.Context) {

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -30,7 +30,6 @@ func gatherOptions() options {
 
 	fs.IntVar(&o.port, "port", 8080, "Port number where the server will listen to")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run mode with a fake calculation agent")
-	fs.StringVar(&o.resultsDir, "calculation-results-dir", "", "Path were the results of the calculations exist.")
 	fs.StringVar(&o.namespace, "namespace", "vega", "The namespace where the calculations exist.")
 	o.simulator.bind(fs)
 
@@ -85,11 +84,12 @@ func main() {
 	r.GET("/bulks", s.getCalculationBulks)
 	r.GET("/bulk/:id", s.getCalculationBulkByName)
 	r.POST("/bulk/create", s.createCalculationBulk)
+	r.DELETE("/bulks/delete/:id", s.deleteCalculationBulk)
 
 	r.GET("/workerpools", s.getWorkerPools)
-
-	r.GET("/calculations/results", s.getCalculationResults)
-	r.GET("/calculations/results/:id", s.getCalculationResultsByID)
+	r.GET("/workerpool/:id", s.getWorkerPoolByName)
+	r.POST("workerpool/create", s.createWorkerPool)
+	r.DELETE("/workerpools/delete/:id", s.deleteWorkerPool)
 
 	r.GET("/healthz", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "OK"})

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	r.GET("/workerpools", s.getWorkerPools)
 	r.GET("/workerpool/:id", s.getWorkerPoolByName)
-	r.POST("workerpool/create", s.createWorkerPool)
+	r.POST("workerpool/create/:id", s.createWorkerPool)
 	r.DELETE("/workerpools/delete/:id", s.deleteWorkerPool)
 
 	r.GET("/healthz", func(c *gin.Context) {

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -64,18 +64,9 @@ func (s *server) createCalculationBulk(c *gin.Context) {
 }
 
 func (s *server) createWorkerPool(c *gin.Context) {
-	body, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		responseError(c, "couldn't read body", err)
-		return
-	}
-
+	workerPoolName := c.Param("id")
 	workerPool := &workersv1.WorkerPool{}
-	if err := json.Unmarshal(body, &workerPool); err != nil {
-		responseError(c, "couldn't unmarshal body", err)
-	}
-
-	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPool.Name)
+	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPoolName)
 
 	workerPoolList := &workersv1.WorkerPoolList{}
 	if err := s.client.List(s.ctx, workerPoolList); err != nil {
@@ -115,7 +106,7 @@ func (s *server) deleteCalculationBulk(c *gin.Context) {
 		}
 		return nil
 	}); err != nil {
-		responseError(c, "retryOnConflict method failed", err)
+		c.JSON(http.StatusInternalServerError, response("500", http.StatusInternalServerError))
 	}
 }
 
@@ -136,7 +127,7 @@ func (s *server) deleteWorkerPool(c *gin.Context) {
 		}
 		return nil
 	}); err != nil {
-		responseError(c, "retryOnConflict method failed", err)
+		c.JSON(http.StatusInternalServerError, response("500", http.StatusInternalServerError))
 	}
 }
 

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -69,11 +69,6 @@ func (s *server) createWorkerPool(c *gin.Context) {
 	workerPool := &workersv1.WorkerPool{}
 	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPoolName)
 
-	if err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: workerPool.Name}, workerPool); err == nil {
-		responseError(c, "workerpool with entered name already exists", err)
-		return
-	}
-
 	s.logger.Infof("Creating the workerpool %s...", workerPool.Name)
 
 	if err := s.client.Create(s.ctx, workerPool); err != nil {

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -60,10 +56,82 @@ func (s *server) createCalculationBulk(c *gin.Context) {
 	}
 
 	if err := s.client.Create(s.ctx, bulk); err != nil {
-		responseError(c, "couldn't create calculation", err)
+		responseError(c, "couldn't create calculation bulk", err)
 	} else {
 		c.JSON(http.StatusOK, gin.H{"data": bulk})
 	}
+}
+
+func (s *server) createWorkerPool(c *gin.Context) {
+	body, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		responseError(c, "couldn't read body", err)
+		return
+	}
+
+	workerPoolName := fmt.Sprintf("workerpool-%s", util.InputHash(body))
+	var workerPools struct {
+		Workers        map[string]workersv1.Worker `json:"workers,omitempty"`
+		CompletionTime metav1.Time                 `json:"completionTime,omitempty"`
+		CreationTime   metav1.Time                 `json:"creationTime,omitempty"`
+		PendingTime    metav1.Time                 `json:"pendingTime,omitempty"`
+	}
+
+	if err := json.Unmarshal(body, &workerPools); err != nil {
+		responseError(c, "couldn't unmarshal body", err)
+	}
+
+	s.logger.Info("Creating the workerpool...")
+
+	wp := &workersv1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: workerPoolName, Namespace: s.namespace},
+		Spec: workersv1.WorkerPoolSpec{
+			Workers: workerPools.Workers,
+		},
+		Status: workersv1.WorkerPoolStatus{
+			CreationTime:   &workerPools.CreationTime,
+			PendingTime:    &workerPools.PendingTime,
+			CompletionTime: &workerPools.CompletionTime,
+		},
+	}
+
+	if err := s.client.Create(s.ctx, wp); err != nil {
+		responseError(c, "couldn't create calculation bulk", err)
+	} else {
+		c.JSON(http.StatusOK, gin.H{"data": wp})
+	}
+}
+
+func (s *server) deleteCalculationBulk(c *gin.Context) {
+	calcBulkName := c.Param("id")
+	bulk := &bulkv1.CalculationBulk{}
+	err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: calcBulkName}, bulk)
+	if err != nil {
+		responseError(c, fmt.Sprintf("failed to get the calculation bulk %s", calcBulkName), err)
+	}
+
+	if err := s.client.Delete(s.ctx, bulk); err != nil {
+		responseError(c, fmt.Sprintf("failed to delete the calculation bulk %s", calcBulkName), err)
+	} else {
+		c.JSON(http.StatusOK, response(fmt.Sprintf("calculation bulk %s has been deleted", calcBulkName), http.StatusOK))
+	}
+
+}
+
+func (s *server) deleteWorkerPool(c *gin.Context) {
+	workerPoolName := c.Param("id")
+	workerpool := &workersv1.WorkerPool{}
+	err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: workerPoolName}, workerpool)
+	if err != nil {
+		responseError(c, fmt.Sprintf("failed to get the workerpool %s", workerPoolName), err)
+	}
+
+	if err := s.client.Delete(s.ctx, workerpool); err != nil {
+		responseError(c, fmt.Sprintf("failed to delete the workerpool %s", workerPoolName), err)
+	} else {
+		c.JSON(http.StatusOK, response(fmt.Sprintf("workerpool %s has been deleted", workerPoolName), http.StatusOK))
+	}
+
 }
 
 func (s *server) deleteCalculation(c *gin.Context) {
@@ -149,93 +217,6 @@ func (s *server) getCalculation(c *gin.Context) {
 	}
 }
 
-func (s *server) sendResults(c *gin.Context, teff, logG float64) {
-	resultDirName := fmt.Sprintf("%.1f___%.2f", teff, logG)
-
-	fort7Data, err := ioutil.ReadFile(filepath.Join(s.resultsPath, resultDirName, "fort.7"))
-	if err != nil {
-		responseError(c, "File reading error", err)
-		return
-	}
-
-	fort8Data, err := ioutil.ReadFile(filepath.Join(s.resultsPath, resultDirName, "fort.8"))
-	if err != nil {
-		responseError(c, "File reading error", err)
-		return
-	}
-
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-	var files = []struct {
-		name string
-		data []byte
-	}{
-		{"fort.7", fort7Data},
-		{"fort.8", fort8Data},
-	}
-	for _, file := range files {
-		hdr := &tar.Header{
-			Name: file.name,
-			Mode: 0600,
-			Size: int64(len(file.data)),
-		}
-		if err := tw.WriteHeader(hdr); err != nil {
-			responseError(c, "couldn't write header while creating the tar file", err)
-			return
-		}
-		if _, err := tw.Write(file.data); err != nil {
-			responseError(c, "couldn't write data while creating the tar file", err)
-			return
-		}
-	}
-
-	if err := tw.Close(); err != nil {
-		responseError(c, "couldn't close the tar file", err)
-		return
-	}
-
-	tarBytes := buf.Bytes()
-	c.Writer.Header().Add("Content-Disposition", "attachment; filename="+fmt.Sprintf("%.1f_%.2f-results.tar.gz", teff, logG))
-	c.Writer.Header().Add("Content-Type", http.DetectContentType(tarBytes))
-
-	tarReader := bytes.NewReader(tarBytes)
-	if _, err := io.Copy(c.Writer, tarReader); err != nil {
-		responseError(c, "couldn't copy data into response writer", err)
-	}
-}
-
-func (s *server) getCalculationResultsByID(c *gin.Context) {
-	calcID := c.Param("id")
-
-	calc := &v1.Calculation{}
-	err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: calcID}, calc)
-	if err != nil {
-		responseError(c, fmt.Sprintf("couldn't get calculation %s", calcID), err)
-		return
-	}
-
-	s.sendResults(c, calc.Spec.Params.Teff, calc.Spec.Params.LogG)
-}
-
-func (s *server) getCalculationResults(c *gin.Context) {
-	teff := c.Query("teff")
-	logG := c.Query("logg")
-
-	t, err := strconv.ParseFloat(teff, 64)
-	if err != nil {
-		responseError(c, "couldn't parse teff as a float number", err)
-		return
-	}
-
-	l, err := strconv.ParseFloat(logG, 64)
-	if err != nil {
-		responseError(c, "couldn't parse logG as a float number", err)
-		return
-	}
-
-	s.sendResults(c, t, l)
-}
-
 func (s *server) getWorkerPools(c *gin.Context) {
 	s.logger.WithFields(logrus.Fields{"host": c.Request.Host, "url": c.Request.URL, "method": c.Request.Method, "user-agent": c.Request.UserAgent()}).Info("getting workerpools")
 
@@ -244,6 +225,18 @@ func (s *server) getWorkerPools(c *gin.Context) {
 		responseError(c, "couldn't get workerpool list", err)
 	} else {
 		c.JSON(http.StatusOK, gin.H{"data": workerPoolList})
+	}
+}
+
+func (s *server) getWorkerPoolByName(c *gin.Context) {
+	workerPoolName := c.Param("id")
+
+	workerPool := &workersv1.WorkerPool{}
+	err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: workerPoolName}, workerPool)
+	if err != nil {
+		responseError(c, fmt.Sprintf("failed to get the workerpool %s", workerPoolName), err)
+	} else {
+		c.JSON(http.StatusOK, gin.H{"data": workerPool})
 	}
 }
 

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -66,9 +66,9 @@ func (s *server) createCalculationBulk(c *gin.Context) {
 func (s *server) createWorkerPool(c *gin.Context) {
 	workerPoolName := c.Query("name")
 
-	workerPool := &workersv1.WorkerPool{}
-	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPoolName)
-	workerPool.Namespace = s.namespace
+	workerPool := &workersv1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("workerpool-%s", workerPoolName), Namespace: s.namespace},
+	}
 
 	s.logger.Infof("Creating the workerpool %s...", workerPool.Name)
 

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -74,9 +74,16 @@ func (s *server) createWorkerPool(c *gin.Context) {
 
 	if err := s.client.Create(s.ctx, workerPool); err != nil {
 		responseError(c, "couldn't create workerpool", err)
-	} else {
-		c.JSON(http.StatusOK, gin.H{"data": workerPool})
+		return
 	}
+
+	newWorkerPool := &workersv1.WorkerPool{}
+	if err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: workerPool.GetNamespace(), Name: workerPool.GetName()}, newWorkerPool); err != nil {
+		responseError(c, "couldn't get the newly created workerpool", err)
+	} else {
+		c.JSON(http.StatusOK, gin.H{"data": newWorkerPool})
+	}
+
 }
 
 func (s *server) deleteCalculationBulk(c *gin.Context) {

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -64,23 +64,10 @@ func (s *server) createCalculationBulk(c *gin.Context) {
 }
 
 func (s *server) createWorkerPool(c *gin.Context) {
-	body, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		responseError(c, "couldn't read body", err)
-		return
-	}
+	workerPoolName := c.Query("name")
 
 	workerPool := &workersv1.WorkerPool{}
-
-	var NameBody struct {
-		Name string `json:"name,omitempty"`
-	}
-
-	if err := json.Unmarshal(body, &NameBody); err != nil {
-		responseError(c, "couldn't unmarshal body", err)
-	}
-
-	workerPool.Name = fmt.Sprintf("workerpool-%s", NameBody.Name)
+	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPoolName)
 
 	if err := s.client.Get(s.ctx, ctrlruntimeclient.ObjectKey{Namespace: s.namespace, Name: workerPool.Name}, workerPool); err == nil {
 		responseError(c, "workerpool with entered name already exists", err)

--- a/cmd/apiserver/server.go
+++ b/cmd/apiserver/server.go
@@ -68,11 +68,12 @@ func (s *server) createWorkerPool(c *gin.Context) {
 
 	workerPool := &workersv1.WorkerPool{}
 	workerPool.Name = fmt.Sprintf("workerpool-%s", workerPoolName)
+	workerPool.Namespace = s.namespace
 
 	s.logger.Infof("Creating the workerpool %s...", workerPool.Name)
 
 	if err := s.client.Create(s.ctx, workerPool); err != nil {
-		responseError(c, "couldn't create calculation bulk", err)
+		responseError(c, "couldn't create workerpool", err)
 	} else {
 		c.JSON(http.StatusOK, gin.H{"data": workerPool})
 	}

--- a/cmd/apiserver/server_test.go
+++ b/cmd/apiserver/server_test.go
@@ -894,40 +894,16 @@ func TestGetWorkerPoolByName(t *testing.T) {
 func TestCreateWorkerPool(t *testing.T) {
 	testCases := []struct {
 		id                 string
-		body               string
+		name               string
 		initialWorkerPools []ctrlruntimeclient.Object
 		expected           []workersv1.WorkerPool
 	}{
 		{
-			id: "no initial workerpools in cluster",
-			body: `{
-					"metadata": {
-						"name": "test1"
-					},
-					"spec": {
-						"workers": {
-							"worker1-test-vega": {
-								"calculationsProcessed": 10,
-								"name": "Name1",
-								"node": "Node1"
-							},
-							"worker2-test-vega": {
-								"calculationsProcessed": 20,
-								"name": "Name2",
-								"node": "Node2"
-							}
-						}
-					}
-			  }`,
+			id:   "no initial workerpools in cluster",
+			name: "test1",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test1"},
-					Spec: workersv1.WorkerPoolSpec{
-						Workers: map[string]workersv1.Worker{
-							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 10},
-							"worker2-test-vega": {Name: "Name2", Node: "Node2", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 20},
-						},
-					},
 				},
 			},
 		},
@@ -936,37 +912,13 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"}},
 			},
-			body: `{
-				"metadata": {
-					"name": "test2"
-				},
-				"spec": {
-					"workers": {
-						"worker1-test-vega": {
-							"calculationsProcessed": 30,
-							"name": "Name1",
-							"node": "Node1"
-						},
-						"worker2-test-vega": {
-							"calculationsProcessed": 40,
-							"name": "Name2",
-							"node": "Node2"
-						}
-					}
-				}
-		  }`,
+			name: "test2",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test2"},
-					Spec: workersv1.WorkerPoolSpec{
-						Workers: map[string]workersv1.Worker{
-							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 30},
-							"worker2-test-vega": {Name: "Name2", Node: "Node2", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 40},
-						},
-					},
 				},
 			},
 		},
@@ -975,25 +927,7 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"}},
 			},
-			body: `{
-				"metadata": {
-					"name": "same-name"
-				},
-				"spec": {
-					"workers": {
-						"worker1-test-vega": {
-							"calculationsProcessed": 20,
-							"name": "Name1",
-							"node": "Node1"
-						},
-						"worker2-test-vega": {
-							"calculationsProcessed": 60,
-							"name": "Name2",
-							"node": "Node2"
-						}
-					}
-				}
-		  }`,
+			name: "same-name",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"},
@@ -1011,13 +945,13 @@ func TestCreateWorkerPool(t *testing.T) {
 			client: fakeClient,
 		}
 
-		req, err := http.NewRequest("POST", "/workerpool/create", bytes.NewBuffer([]byte(tc.body)))
+		req, err := http.NewRequest("POST", fmt.Sprintf("/workerpool/create/%s", tc.name), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		r := gin.Default()
-		r.POST("/workerpool/create", s.createWorkerPool)
+		r.POST("/workerpool/create/:id", s.createWorkerPool)
 
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)

--- a/cmd/apiserver/server_test.go
+++ b/cmd/apiserver/server_test.go
@@ -901,22 +901,27 @@ func TestCreateWorkerPool(t *testing.T) {
 		{
 			id: "no initial workerpools in cluster",
 			body: `{
-					"workers": {
-						"worker1-test-vega": {
-							"calculationsProcessed": 10,
-							"name": "Name1",
-							"node": "Node1"
-						},
-						"worker2-test-vega": {
-							"calculationsProcessed": 20,
-							"name": "Name2",
-							"node": "Node2"
+					"metadata": {
+						"name": "test1"
+					},
+					"spec": {
+						"workers": {
+							"worker1-test-vega": {
+								"calculationsProcessed": 10,
+								"name": "Name1",
+								"node": "Node1"
+							},
+							"worker2-test-vega": {
+								"calculationsProcessed": 20,
+								"name": "Name2",
+								"node": "Node2"
+							}
 						}
 					}
 			  }`,
 			expected: []workersv1.WorkerPool{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-lmskqxlm1qhfdvyt"},
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test1"},
 					Spec: workersv1.WorkerPoolSpec{
 						Workers: map[string]workersv1.Worker{
 							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 10},
@@ -932,16 +937,21 @@ func TestCreateWorkerPool(t *testing.T) {
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"}},
 			},
 			body: `{
-				"workers": {
-					"worker1-test-vega": {
-						"calculationsProcessed": 30,
-						"name": "Name1",
-						"node": "Node1"
-					},
-					"worker2-test-vega": {
-						"calculationsProcessed": 40,
-						"name": "Name2",
-						"node": "Node2"
+				"metadata": {
+					"name": "test2"
+				},
+				"spec": {
+					"workers": {
+						"worker1-test-vega": {
+							"calculationsProcessed": 30,
+							"name": "Name1",
+							"node": "Node1"
+						},
+						"worker2-test-vega": {
+							"calculationsProcessed": 40,
+							"name": "Name2",
+							"node": "Node2"
+						}
 					}
 				}
 		  }`,
@@ -950,13 +960,43 @@ func TestCreateWorkerPool(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-nhil147z6y82jvgk"},
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test2"},
 					Spec: workersv1.WorkerPoolSpec{
 						Workers: map[string]workersv1.Worker{
 							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 30},
 							"worker2-test-vega": {Name: "Name2", Node: "Node2", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 40},
 						},
 					},
+				},
+			},
+		},
+		{
+			id: "initial workerpool in a cluster, try to create a new workerpool with the same name",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"}},
+			},
+			body: `{
+				"metadata": {
+					"name": "same-name"
+				},
+				"spec": {
+					"workers": {
+						"worker1-test-vega": {
+							"calculationsProcessed": 20,
+							"name": "Name1",
+							"node": "Node1"
+						},
+						"worker2-test-vega": {
+							"calculationsProcessed": 60,
+							"name": "Name2",
+							"node": "Node2"
+						}
+					}
+				}
+		  }`,
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"},
 				},
 			},
 		},

--- a/cmd/apiserver/server_test.go
+++ b/cmd/apiserver/server_test.go
@@ -894,15 +894,13 @@ func TestGetWorkerPoolByName(t *testing.T) {
 func TestCreateWorkerPool(t *testing.T) {
 	testCases := []struct {
 		id                 string
-		body               string
+		name               string
 		initialWorkerPools []ctrlruntimeclient.Object
 		expected           []workersv1.WorkerPool
 	}{
 		{
-			id: "no initial workerpools in cluster",
-			body: `{
-					"name": "test1"
-				}`,
+			id:   "no initial workerpools in cluster",
+			name: "test1",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test1"},
@@ -914,9 +912,7 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"}},
 			},
-			body: `{
-				"name": "test2"
-			}`,
+			name: "test2",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"},
@@ -931,9 +927,7 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"}},
 			},
-			body: `{
-				"name": "same-name"
-			}`,
+			name: "same-name",
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"},
@@ -951,10 +945,14 @@ func TestCreateWorkerPool(t *testing.T) {
 			client: fakeClient,
 		}
 
-		req, err := http.NewRequest("POST", "/workerpool/create", bytes.NewBuffer([]byte(tc.body)))
+		req, err := http.NewRequest("POST", "/workerpool/create", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		q := req.URL.Query()
+		q.Add("name", fmt.Sprintf("%v", tc.name))
+		req.URL.RawQuery = q.Encode()
 
 		r := gin.Default()
 		r.POST("/workerpool/create", s.createWorkerPool)

--- a/cmd/apiserver/server_test.go
+++ b/cmd/apiserver/server_test.go
@@ -894,13 +894,15 @@ func TestGetWorkerPoolByName(t *testing.T) {
 func TestCreateWorkerPool(t *testing.T) {
 	testCases := []struct {
 		id                 string
-		name               string
+		body               string
 		initialWorkerPools []ctrlruntimeclient.Object
 		expected           []workersv1.WorkerPool
 	}{
 		{
-			id:   "no initial workerpools in cluster",
-			name: "test1",
+			id: "no initial workerpools in cluster",
+			body: `{
+					"name": "test1"
+				}`,
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-test1"},
@@ -912,7 +914,9 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"}},
 			},
-			name: "test2",
+			body: `{
+				"name": "test2"
+			}`,
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"},
@@ -927,7 +931,9 @@ func TestCreateWorkerPool(t *testing.T) {
 			initialWorkerPools: []ctrlruntimeclient.Object{
 				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"}},
 			},
-			name: "same-name",
+			body: `{
+				"name": "same-name"
+			}`,
 			expected: []workersv1.WorkerPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-same-name"},
@@ -945,13 +951,13 @@ func TestCreateWorkerPool(t *testing.T) {
 			client: fakeClient,
 		}
 
-		req, err := http.NewRequest("POST", fmt.Sprintf("/workerpool/create/%s", tc.name), nil)
+		req, err := http.NewRequest("POST", "/workerpool/create", bytes.NewBuffer([]byte(tc.body)))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		r := gin.Default()
-		r.POST("/workerpool/create/:id", s.createWorkerPool)
+		r.POST("/workerpool/create", s.createWorkerPool)
 
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)

--- a/cmd/apiserver/server_test.go
+++ b/cmd/apiserver/server_test.go
@@ -786,3 +786,519 @@ func TestGetWorkerPools(t *testing.T) {
 		}
 	}
 }
+
+func TestGetWorkerPoolByName(t *testing.T) {
+	testCases := []struct {
+		id                string
+		initialWorkerPool []ctrlruntimeclient.Object
+		expected          workersv1.WorkerPool
+		errorExpected     bool
+	}{
+		{
+			id: "get one workerpool by name",
+			initialWorkerPool: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-1"},
+					Spec: workersv1.WorkerPoolSpec{
+						Workers: map[string]workersv1.Worker{
+							"worker1": {Name: "worker-name", RegisteredTime: &metav1.Time{}, State: workersv1.WorkerUnknownState, LastUpdateTime: &metav1.Time{}, CalculationsProcessed: 0},
+						},
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "WorkerPool", APIVersion: "vegaproject.io/v1"},
+					Status: workersv1.WorkerPoolStatus{
+						CreationTime:   &metav1.Time{},
+						PendingTime:    &metav1.Time{},
+						CompletionTime: &metav1.Time{},
+					},
+				},
+			},
+			expected: workersv1.WorkerPool{
+				TypeMeta:   metav1.TypeMeta{Kind: "WorkerPool", APIVersion: "vegaproject.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "workerpool-1"},
+				Spec: workersv1.WorkerPoolSpec{
+					Workers: map[string]workersv1.Worker{
+						"worker1": {Name: "worker-name", RegisteredTime: nil, State: workersv1.WorkerUnknownState, LastUpdateTime: nil, CalculationsProcessed: 0},
+					},
+				},
+				Status: workersv1.WorkerPoolStatus{
+					CreationTime:   nil,
+					PendingTime:    nil,
+					CompletionTime: nil,
+				},
+			},
+		},
+		{
+			id: "get a workerpools by a wrong name",
+			initialWorkerPool: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-does-not-exist"},
+					Spec: workersv1.WorkerPoolSpec{
+						Workers: map[string]workersv1.Worker{
+							"worker1": {Name: "worker-name", RegisteredTime: &metav1.Time{}, State: workersv1.WorkerUnknownState, LastUpdateTime: &metav1.Time{}, CalculationsProcessed: 0},
+						},
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "WorkerPool"},
+					Status: workersv1.WorkerPoolStatus{
+						CreationTime:   &metav1.Time{},
+						PendingTime:    &metav1.Time{},
+						CompletionTime: &metav1.Time{},
+					},
+				},
+			},
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		fakeClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.initialWorkerPool...).Build()
+
+		s := server{
+			logger: logrus.WithField("test-name", tc.id),
+			ctx:    context.Background(),
+			client: fakeClient,
+		}
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("/workerpool/%s", tc.initialWorkerPool[0].GetName()), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := gin.Default()
+		r.GET("/workerpool/:id", s.getWorkerPoolByName)
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("Handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+
+		var actualData struct {
+			Data *workersv1.WorkerPool `json:"data,omitempty"`
+		}
+
+		err = json.Unmarshal(rr.Body.Bytes(), &actualData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(tc.expected, *actualData.Data, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+			if !tc.errorExpected {
+				t.Fatal(diff)
+			}
+		}
+	}
+}
+
+func TestCreateWorkerPool(t *testing.T) {
+	testCases := []struct {
+		id                 string
+		body               string
+		initialWorkerPools []ctrlruntimeclient.Object
+		expected           []workersv1.WorkerPool
+	}{
+		{
+			id: "no initial workerpools in cluster",
+			body: `{
+					"workers": {
+						"worker1-test-vega": {
+							"calculationsProcessed": 10,
+							"name": "Name1",
+							"node": "Node1"
+						},
+						"worker2-test-vega": {
+							"calculationsProcessed": 20,
+							"name": "Name2",
+							"node": "Node2"
+						}
+					}
+			  }`,
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-lmskqxlm1qhfdvyt"},
+					Spec: workersv1.WorkerPoolSpec{
+						Workers: map[string]workersv1.Worker{
+							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 10},
+							"worker2-test-vega": {Name: "Name2", Node: "Node2", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 20},
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "initial workerpools in cluster",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"}},
+			},
+			body: `{
+				"workers": {
+					"worker1-test-vega": {
+						"calculationsProcessed": 30,
+						"name": "Name1",
+						"node": "Node1"
+					},
+					"worker2-test-vega": {
+						"calculationsProcessed": 40,
+						"name": "Name2",
+						"node": "Node2"
+					}
+				}
+		  }`,
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-4d5g2z03whjr64v8"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-nhil147z6y82jvgk"},
+					Spec: workersv1.WorkerPoolSpec{
+						Workers: map[string]workersv1.Worker{
+							"worker1-test-vega": {Name: "Name1", Node: "Node1", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 30},
+							"worker2-test-vega": {Name: "Name2", Node: "Node2", RegisteredTime: nil, LastUpdateTime: nil, CalculationsProcessed: 40},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		fakeClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.initialWorkerPools...).Build()
+
+		s := server{
+			logger: logrus.WithField("test-name", tc.id),
+			ctx:    context.Background(),
+			client: fakeClient,
+		}
+
+		req, err := http.NewRequest("POST", "/workerpool/create", bytes.NewBuffer([]byte(tc.body)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := gin.Default()
+		r.POST("/workerpool/create", s.createWorkerPool)
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		var actualData struct {
+			Data *workersv1.WorkerPool `json:"data,omitempty"`
+		}
+
+		if err := json.Unmarshal(rr.Body.Bytes(), &actualData); err != nil {
+			t.Fatal(err)
+		}
+
+		var workerPoolList workersv1.WorkerPoolList
+		if err := fakeClient.List(s.ctx, &workerPoolList); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(tc.expected, workerPoolList.Items,
+			cmpopts.IgnoreFields(metav1.Time{}, "Time"),
+			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+			cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion")); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}
+
+func TestDeleteCalculationBulk(t *testing.T) {
+	testCases := []struct {
+		id                      string
+		calculationBulkToDelete string
+		initialCalculationBulks []ctrlruntimeclient.Object
+		expected                []bulkv1.CalculationBulk
+		errorExpected           bool
+	}{
+		{
+			id:                      "one calculation bulk, none gets deleted",
+			calculationBulkToDelete: "bulk-wrong-name",
+			initialCalculationBulks: []ctrlruntimeclient.Object{
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-1"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			expected: []bulkv1.CalculationBulk{
+				{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-1"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			id:                      "one calculation bulk, one gets deleted",
+			calculationBulkToDelete: "bulk-delete",
+			initialCalculationBulks: []ctrlruntimeclient.Object{
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-delete"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			expected: []bulkv1.CalculationBulk{},
+		},
+		{
+			id:                      "one out of X calculation bulks get deleted",
+			calculationBulkToDelete: "bulk-delete",
+			initialCalculationBulks: []ctrlruntimeclient.Object{
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-delete"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			expected: []bulkv1.CalculationBulk{
+				{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: nil,
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+		},
+		{
+			id:                      "none out of X calculation bulks get deleted",
+			calculationBulkToDelete: "bulk-wrong-name",
+			initialCalculationBulks: []ctrlruntimeclient.Object{
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains-1"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+				&bulkv1.CalculationBulk{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains-2"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: map[string]bulkv1.Calculation{},
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			expected: []bulkv1.CalculationBulk{
+				{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains-1"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: nil,
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+				{
+					ObjectMeta:   metav1.ObjectMeta{Name: "bulk-remains-2"},
+					RootFolder:   "root-folder",
+					WorkerPool:   "vega-workerpool",
+					InputFiles:   &v1.InputFiles{},
+					Calculations: nil,
+					Status:       bulkv1.CalculationBulkStatus{},
+				},
+			},
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		print("hello")
+		t.Run(tc.id, func(t *testing.T) {
+			fakeClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.initialCalculationBulks...).Build()
+
+			s := server{
+				logger: logrus.WithField("test-name", tc.id),
+				ctx:    context.Background(),
+				client: fakeClient,
+			}
+
+			req, err := http.NewRequest("DELETE", fmt.Sprintf("/bulks/delete/%s", tc.calculationBulkToDelete), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			r := gin.Default()
+			r.DELETE("/bulks/delete/:id", s.deleteCalculationBulk)
+
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			var calculationBulkList bulkv1.CalculationBulkList
+			if err := fakeClient.List(s.ctx, &calculationBulkList); err != nil {
+				t.Fatal(err)
+			}
+
+			if status := rr.Code; status == http.StatusOK {
+				logrus.Info(rr.Body)
+			} else if status != http.StatusOK {
+				logrus.Info(rr.Body)
+			}
+
+			if diff := cmp.Diff(tc.expected, calculationBulkList.Items,
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion")); diff != "" && !tc.errorExpected {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestDeleteWorkerPool(t *testing.T) {
+	testCases := []struct {
+		id                 string
+		workerPoolToDelete string
+		initialWorkerPools []ctrlruntimeclient.Object
+		expected           []workersv1.WorkerPool
+		errorExpected      bool
+	}{
+		{
+			id:                 "one workerpool, none gets deleted",
+			workerPoolToDelete: "workerpool-wrong-name",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-1"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-1"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			id:                 "one workerpool, one gets deleted",
+			workerPoolToDelete: "workerpool-delete",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-delete"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			expected: []workersv1.WorkerPool{},
+		},
+		{
+			id:                 "one out of X workerpools get deleted",
+			workerPoolToDelete: "workerpool-delete",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-delete"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+		},
+		{
+			id:                 "none out of X workerpools get deleted",
+			workerPoolToDelete: "workerpool-wrong-name",
+			initialWorkerPools: []ctrlruntimeclient.Object{
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains-1"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+				&workersv1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains-2"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			expected: []workersv1.WorkerPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains-1"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "workerpool-remains-2"},
+					Spec:       workersv1.WorkerPoolSpec{},
+					Status:     workersv1.WorkerPoolStatus{},
+				},
+			},
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			fakeClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.initialWorkerPools...).Build()
+
+			s := server{
+				logger: logrus.WithField("test-name", tc.id),
+				ctx:    context.Background(),
+				client: fakeClient,
+			}
+
+			req, err := http.NewRequest("DELETE", fmt.Sprintf("/workerpools/delete/%s", tc.workerPoolToDelete), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			r := gin.Default()
+			r.DELETE("/workerpools/delete/:id", s.deleteWorkerPool)
+
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			var workerPoolList workersv1.WorkerPoolList
+			if err := fakeClient.List(s.ctx, &workerPoolList); err != nil {
+				t.Fatal(err)
+			}
+
+			if status := rr.Code; status == http.StatusOK {
+				logrus.Info(rr.Body)
+			} else if status != http.StatusOK {
+				logrus.Info(rr.Body)
+			}
+
+			if diff := cmp.Diff(tc.expected, workerPoolList.Items,
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion")); diff != "" && !tc.errorExpected {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi @droslean,
added the functionality to the API as we spoke earlier. Results endpoints are deleted.

calculations -> GET, LIST
bulks -> CREATE, GET, LIST, DELETE
workerpool -> CREATE, GET, LIST, DELETE

Also added unit tests for the methods.